### PR TITLE
chore(): update npm publish 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,60 +2,62 @@ name: Publish to NPM
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*.*.*'
 
 permissions:
-  id-token: 'write'
-  contents: 'read'
+  contents: read
+  id-token: write
 
 jobs:
   publish-npm:
-    name: 'Publish NPM'
+    environment: production
     runs-on: ubuntu-latest
-
     steps:
-      - name: 'Checkout source code'
+      - name: Checkout (no repo token persisted)
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org/'
+          registry-url: https://registry.npmjs.org/
           cache: 'npm'
 
-      - name: Install
+      - name: Assert latest npm
+        run: npm i -g npm@latest
+
+      - name: Guard - block registry overrides and shady files
+        run: |
+          # fail if any .npmrc exists in repo
+          if git ls-files -z | xargs -0 -I{} bash -lc '[[ "{}" == *.npmrc ]]' | grep -q .; then
+            echo "Repo contains an .npmrc. Refusing to publish."; exit 1;
+          fi
+          # fail if publishConfig.registry set
+          node -e "const p=require('./package.json'); if(p.publishConfig?.registry){console.error('publishConfig.registry present — refuse to publish'); process.exit(1)}"
+          # optional: block workflow/script changes in the release commit
+          # git diff --name-only HEAD~1..HEAD | grep -E '^\.github/(workflows|scripts)/' && { echo 'Workflow/scripts changed in release commit — refuse.'; exit 1; } || true
+          SHA=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          PARENT=$(git rev-list -n 1 "$SHA^")
+          git diff --name-only "$PARENT" "$SHA" | grep -E '^\.github/(workflows|scripts)/' \
+            && { echo 'Workflow/scripts changed in release commit — refuse.'; exit 1; } || true
+
+      - name: Verify tag matches package version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG="${GITHUB_REF_NAME#v}"
+          [[ "$PKG_VERSION" == "$TAG" ]] || { echo "Tag v$TAG != package.json $PKG_VERSION"; exit 1; }
+
+      - name: Install deps (no lifecycle scripts)
         run: npm ci --ignore-scripts
 
-      - name: Build
-        run: npm run build
+      - run: npm run clean
+      - run: npm run build
 
-      - name: Test
-        run: npm run test
-
-      - name: Check if version has been updated
-        id: check
-        uses: EndBug/version-check@v2
-
-      - name: Log when changed
-        if: steps.check.outputs.changed == 'true'
-        run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
-
-      - name: Log when unchanged
-        if: steps.check.outputs.changed == 'false'
-        run: 'echo "No version change :/"'
-
-      # - name: Bump version & push
-      #   run: |
-      #     git config --global user.name 'Automated publish'
-      #     git config --global user.email 'tiagosiebler@users.noreply.github.com'
-
-      #     # Update the version in package.json, and commit & tag the change:
-      #     npm version patch # YMMV - you might want the semver level as a workflow input
-
-      #     git push && git push --tags
-
-      - run: npm publish --provenance
-        if: steps.check.outputs.changed == 'true'
+      - name: Publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: npm publish --access public --ignore-scripts --registry=https://registry.npmjs.org/ --provenance


### PR DESCRIPTION
- Change trigger from master branch to version tags (v*.*.*).
- Simplify permissions configuration.
- Add steps to assert latest npm version and guard against registry overrides.
- Verify that the tag matches the package version before publishing.
- Remove unnecessary steps related to version checking and logging.
- Ensure clean build and publish process with updated npm publish command.

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
